### PR TITLE
Likvido/Likvido.App#24281 Log an error before moving the message to t…

### DIFF
--- a/src/Likvido.QueueRobot/MessageProcessing/QueueMessageProcessor.cs
+++ b/src/Likvido.QueueRobot/MessageProcessing/QueueMessageProcessor.cs
@@ -92,6 +92,7 @@ internal sealed class QueueMessageProcessor : IDisposable
             {
                 if (IsLastAttempt(messageDetails))
                 {
+                    _logger.LogError(postponeProcessingException, "We have reached the maximum retry count for message {MessageId}, so we cannot postpone it again. Moving to poison queue.", messageDetails.Message.MessageId);
                     await TryMoveToPoisonAsync(_queueClient, messageDetails, updateVisibilityStopAction);
                 }
                 else

--- a/src/version.props
+++ b/src/version.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>3.2.8</Version>
+        <Version>3.3.0</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
…he poison queue, when we are handling the postpone processing exception, and we reached the max retry count


Likvido/Likvido.App#24281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error logging when messages reach the maximum retry count and are moved to the poison queue. The log now includes the message ID and exception details for better traceability.

- **Chores**
  - Updated the project version to 3.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->