### PR TITLE
Pin Azure.Core to 1.60.0 (AIKIDO-2026-895105)

### DIFF
--- a/src/Likvido.QueueRobot/Likvido.QueueRobot.csproj
+++ b/src/Likvido.QueueRobot/Likvido.QueueRobot.csproj
@@ -15,6 +15,9 @@
         <PackageReference Include="Likvido.CloudEvents" Version="1.2.0" />
         <PackageReference Include="Likvido.Robot" Version="2.3.36" />
         <PackageReference Include="Azure.Storage.Queues" Version="12.27.1" />
+        <!-- Pinned above Azure.Storage.Queues' floor (1.55.0) for AIKIDO-2026-895105:
+             Azure.Core < 1.59.0 re-attaches the Authorization header on cross-host redirects. -->
+        <PackageReference Include="Azure.Core" Version="1.60.0" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.10" />
         <PackageReference Include="Polly.Core" Version="8.7.0" />
     </ItemGroup>


### PR DESCRIPTION
Aikido MEDIUM `AIKIDO-2026-895105` (score 59, CWE-200/CWE-522) flags `Azure.Core` < 1.59.0.

**This one is real.** The [Azure.Core 1.59.0 changelog](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/CHANGELOG.md) fixes `BearerTokenAuthenticationPolicy` re-attaching the `Authorization` header to a request redirected to a *different host* — a credential-disclosure bug matching the reported CWEs. The affected projects here genuinely resolved `Azure.Core` below 1.59.0, confirmed with `dotnet list package --include-transitive` and `dotnet nuget why`.

**Why a direct pin instead of a parent bump** (normally preferred): there is no parent left to bump. `Azure.Identity` 1.21.0, `Azure.Storage.Queues` 12.27.1, `Azure.Storage.Blobs` 12.29.1 and `Azure.Extensions.AspNetCore.DataProtection.Blobs` 1.5.3 are all already the latest stable releases, and even those declare `Azure.Core` floors of only 1.53.0–1.55.0. A direct `PackageReference` is the only way to reach the patched floor. 1.60.0 matches the floor `Likvido.Azure` 4.0.1 already declares, keeping the estate on a single version.

These pins should be dropped once upstream ships parents with a floor >= 1.59.0.

Verified: `dotnet restore` and `dotnet build` clean; the affected projects now resolve `Azure.Core` 1.60.0.
